### PR TITLE
Update Dockerfile for VSCode notebook compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@
 #  JupyterLab application directory is  /usr/local/share/jupyter/lab
 
 #may include suffix
-ARG OPENSTUDIO_VERSION=3.6.1
-FROM nrel/openstudio:3.6.1 as base
+ARG OPENSTUDIO_VERSION=3.9.0
+FROM nrel/openstudio:3.9.0 as base
 MAINTAINER Brian Ball brian.ball@nrel.gov
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -87,4 +87,4 @@ RUN VERSION=$(cat /app/version.txt | tr -d '\r\n') && \
 ENTRYPOINT ["/bin/sh", "-c", ". /etc/profile && exec \"$@\"", "--"]
 
 EXPOSE 8888
-CMD ["jupyter-lab", "--ip=0.0.0.0","--port=8888" ,"--no-browser", "--allow-root", "--LabApp.token=''"]
+CMD ["jupyter-lab", "--ip=0.0.0.0","--port=8888" ,"--no-browser", "--allow-root", "--LabApp.token=''", "--NotebookApp.disable_check_xsrf=True"]


### PR DESCRIPTION
Two small changes to Dockerfile:
1.  The primary change was to fix an issue I ran into while trying to connect to the jupyter server from VSCode. I modified the final command in Dockerfile to disable the xsrf check. Disabling the xsrf check allows VSCode to connect to the remote notebook and run code. Otherwise it throws a `wrote error: "'_xsrf' argument missing from POST"` error on the server and VSCode hangs. Since the server already runs the notebook without authentication and is meant to be run locally I don't think this is an issue.
2.  Updated the Openstudio args at the top to the current version of Openstudio and to use the current Openstudio image. I see there's already a pull request to update the docker-compose file so I left that alone. This change isn't as critical but I thought I'd leave it included in the pull request as a general update.

This was the only way I've gotten this to work so far, but if someone has a different suggestion I'm all ears.